### PR TITLE
default to auto-acceptance

### DIFF
--- a/cerb_code/lib/prompts.py
+++ b/cerb_code/lib/prompts.py
@@ -151,7 +151,21 @@ PROJECT_CONF = """
     "defaultMode": "acceptEdits",
     "allow": [
       "Edit",
+      "Glob",
+      "Grep",
+      "LS",
+      "MultiEdit",
+      "Read",
       "Write",
+      "Bash(cat:*)",
+      "Bash(cp:*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
+      "Bash(mkdir:*)",
+      "Bash(pwd:*)",
+      "Bash(rg:*)",
+      "Bash(tail:*)",
+      "Bash(tree:*)",
       "mcp__cerb-subagent"
     ]
   }


### PR DESCRIPTION
- move `defaultMode` property to be within `permissions` so it is actually used by Claude Code
- add commonly-used tools to the allowlist