### PR TITLE
Fix 's' key not working on startup by auto-selecting first session

### DIFF
--- a/cerb_code/runners/kerberos.py
+++ b/cerb_code/runners/kerberos.py
@@ -373,6 +373,10 @@ class UnifiedApp(App):
                 if session.session_id == selected_session_id:
                     self.session_list.index = i
                     break
+        elif self.flat_sessions:
+            # If no selection exists but we have sessions, select the first one
+            self.session_list.index = 0
+            logger.info("Auto-selected first session in list")
 
         # Don't save here - this causes an infinite loop with the file watcher!
 
@@ -615,7 +619,7 @@ class UnifiedApp(App):
         # Get the highlighted session from the list
         index = self.session_list.index
         if index is None or index >= len(self.flat_sessions):
-            logger.warning("No session highlighted to open spec for")
+            logger.warning("No session selected to open spec for")
             return
 
         session = self.flat_sessions[index]


### PR DESCRIPTION
The 's' key to open spec editor would fail on startup with "no session selected" even though the main/designer session was displayed. This was because the session was attached (displayed in pane) but never selected in the UI list.

Changes:
- Auto-select first session in list when no selection exists (after refresh)
- Add status indicator feedback for spec editor operations
- Improve error handling with try-catch blocks and timeout protection
- Use $EDITOR environment variable (defaults to vim)
- Make 's' key binding visible in HUD

@codex take a look