### PR TITLE
Fix pair mode creating circular symlinks for designer sessions

### DIFF
--- a/cerb_code/lib/sessions.py
+++ b/cerb_code/lib/sessions.py
@@ -267,6 +267,9 @@ class Session:
         if not self.protocol:
             return False, "No protocol configured"
 
+        if self.agent_type == AgentType.DESIGNER:
+            return False, "Pairing is not supported for designer sessions"
+
         # Let protocol handle all the implementation details
         return self.protocol.toggle_pairing(self)
 

--- a/cerb_code/runners/kerberos.py
+++ b/cerb_code/runners/kerberos.py
@@ -600,6 +600,11 @@ class UnifiedApp(App):
 
         session = self.flat_sessions[index]
 
+        # Prevent pairing for designer sessions (they work directly in source_path)
+        if session.agent_type == AgentType.DESIGNER:
+            self.status_indicator.update("⚠ Pairing not supported for designer sessions")
+            return
+
         # Check if this session is currently paired (UI state)
         is_paired = (self.paired_session_id == session.session_id)
 


### PR DESCRIPTION
Designer sessions work directly in source_path (no separate worktree), so attempting to pair would create a circular symlink (source -> source), causing "too many symlinks" errors.

Solution: Prevent pairing at designer level with clear error messages at both the Session and UI layers.

@codex