### PR TITLE
Fix MCP transport configuration to use HTTP/streamable-http

### DIFF
--- a/cerb_code/backend/mcp_server.py
+++ b/cerb_code/backend/mcp_server.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from mcp.server import FastMCP
 
 from cerb_code.lib.sessions import load_sessions, save_session, find_session
+from cerb_code.lib.config import load_config
 
 # Create FastMCP server instance
-port = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
+config = load_config()
+default_port = config.get("mcp_port", 8765)
+port = int(sys.argv[1]) if len(sys.argv) > 1 else default_port
 host = "0.0.0.0"
 mcp = FastMCP("cerb-subagent", port=port, host=host)
 
@@ -74,9 +77,9 @@ def send_message_to_session(session_name: str, message: str, source_path: str) -
 
 def main():
     """Entry point for MCP server."""
-    # Run the SSE server
+    # Run the HTTP server
     print(f"Starting MCP server on port {port}...")
-    mcp.run(transport="sse")
+    mcp.run(transport="streamable-http")
 
 
 if __name__ == "__main__":

--- a/cerb_code/lib/helpers.py
+++ b/cerb_code/lib/helpers.py
@@ -291,7 +291,7 @@ def ensure_shared_claude_config(shared_claude_dir: Path, shared_claude_json: Pat
     shared_claude_dir.mkdir(parents=True, exist_ok=True)
 
     # MCP URL for Docker containers (always uses host.docker.internal)
-    mcp_url = f"http://host.docker.internal:{mcp_port}/sse"
+    mcp_url = f"http://host.docker.internal:{mcp_port}/mcp"
 
     # Initialize or update shared .claude.json
     config = {}
@@ -318,8 +318,11 @@ def ensure_shared_claude_config(shared_claude_dir: Path, shared_claude_json: Pat
                 config = json.load(f)
             logger.info(f"Loaded config from host's .claude.json")
 
-    # Inject MCP server configuration
-    config.setdefault("mcpServers", {})["cerb-mcp"] = {"url": mcp_url, "type": "sse"}
+    # Inject MCP server configuration (HTTP transport)
+    config.setdefault("mcpServers", {})["cerb-mcp"] = {
+        "url": mcp_url,
+        "type": "http",
+    }
 
     # Write config
     with open(shared_claude_json, "w") as f:

--- a/cerb_code/lib/monitor.py
+++ b/cerb_code/lib/monitor.py
@@ -1,5 +1,6 @@
 from .sessions import Session
 from .logger import get_logger
+from .config import load_config
 
 from dataclasses import dataclass, field
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
@@ -88,8 +89,15 @@ class SessionMonitor:
             agent_type=self.session.agent_type.value if self.session.agent_type else "unknown",
         )
 
-        # MCP config to give monitor access to send_message_to_session
-        mcp_config = {"cerb-subagent": {"command": "cerb-mcp", "args": [], "env": {}}}
+        # MCP config to give monitor access to send_message_to_session via HTTP transport
+        config = load_config()
+        mcp_port = config.get("mcp_port", 8765)
+        mcp_config = {
+            "cerb-subagent": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{mcp_port}/mcp",
+            }
+        }
 
         options = ClaudeAgentOptions(
             cwd=self.session.work_path,

--- a/cerb_code/lib/tmux_agent.py
+++ b/cerb_code/lib/tmux_agent.py
@@ -292,10 +292,10 @@ class TmuxProtocol(AgentProtocol):
             return
 
         # MCP URL for local sessions (localhost, not host.docker.internal)
-        mcp_url = f"http://localhost:{self.mcp_port}/sse"
+        mcp_url = f"http://localhost:{self.mcp_port}/mcp"
 
         # Create .mcp.json in the session's worktree
-        mcp_config = {"mcpServers": {"cerb-mcp": {"url": mcp_url, "type": "sse"}}}
+        mcp_config = {"mcpServers": {"cerb-mcp": {"url": mcp_url, "type": "http"}}}
 
         mcp_config_path = Path(session.work_path) / ".mcp.json"
         try:

--- a/cerb_code/runners/kerberos.py
+++ b/cerb_code/runners/kerberos.py
@@ -27,7 +27,7 @@ def main():
     config = load_config()
     mcp_port = config.get("mcp_port", 8765)
 
-    # Start the MCP server in the background
+    # Start the MCP server in the background (HTTP transport)
     mcp_log = Path.home() / ".kerberos" / "mcp-server.log"
     mcp_log.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Changes:
- Server (mcp_server.py): Use streamable-http transport (FastMCP requirement)
- Client configs: Use "http" type (Claude Code requirement)
- Updated all MCP URL endpoints from /sse to /mcp
- Fixed helpers.py, tmux_agent.py, and monitor.py MCP configs
- Added config loading to mcp_server.py for consistent port usage

This resolves the MCP connection issues where Claude Code couldn't connect to the Orchestra MCP server due to transport type mismatch.

@codex take a look, also @Uzay-G 