### PR TITLE
Move managed files to .orchestra/ directory and auto-gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 .mcp.json
 instructions.md
+.orchestra/

--- a/cerb_code/frontend/app.py
+++ b/cerb_code/frontend/app.py
@@ -45,6 +45,7 @@ from cerb_code.lib.helpers import (
     respawn_pane_with_vim,
     respawn_pane_with_terminal,
     ensure_docker_image,
+    ensure_orchestra_in_gitignore,
     PANE_AGENT,
 )
 
@@ -223,6 +224,9 @@ class UnifiedApp(App):
 
     async def on_ready(self) -> None:
         """Load sessions and refresh list"""
+        # Ensure .orchestra/ is in .gitignore
+        ensure_orchestra_in_gitignore(self.state.project_dir)
+
         # Build docker image in background if needed
         config = load_config()
         if config.get("use_docker", True):
@@ -414,7 +418,9 @@ class UnifiedApp(App):
         if not session:
             return
         work_path = Path(session.work_path)
-        designer_md = work_path / "designer.md"
+        orchestra_dir = work_path / ".orchestra"
+        orchestra_dir.mkdir(exist_ok=True)
+        designer_md = orchestra_dir / "designer.md"
 
         if not designer_md.exists():
             designer_md.touch()

--- a/cerb_code/lib/helpers.py
+++ b/cerb_code/lib/helpers.py
@@ -339,3 +339,36 @@ def docker_exec(container_name: str, cmd: list[str]) -> subprocess.CompletedProc
         stderr=subprocess.PIPE,
         text=True,
     )
+
+
+def ensure_orchestra_in_gitignore(project_dir: Path) -> None:
+    """Ensure .orchestra/ is in the project's .gitignore file
+
+    Args:
+        project_dir: Path to the project directory
+    """
+    gitignore_path = project_dir / ".gitignore"
+    orchestra_entry = ".orchestra/"
+
+    # Read existing gitignore or create new content
+    if gitignore_path.exists():
+        content = gitignore_path.read_text()
+        lines = content.splitlines()
+    else:
+        content = ""
+        lines = []
+
+    # Check if .orchestra/ is already in gitignore
+    if any(line.strip() == orchestra_entry for line in lines):
+        logger.debug(f".orchestra/ already in {gitignore_path}")
+        return
+
+    # Add .orchestra/ to gitignore
+    if content and not content.endswith('\n'):
+        # Ensure there's a newline before adding new entry
+        new_content = content + '\n' + orchestra_entry + '\n'
+    else:
+        new_content = content + orchestra_entry + '\n'
+
+    gitignore_path.write_text(new_content)
+    logger.info(f"Added .orchestra/ to {gitignore_path}")

--- a/cerb_code/lib/monitor.py
+++ b/cerb_code/lib/monitor.py
@@ -129,8 +129,12 @@ class SessionMonitor:
         self.queue.put_nowait(evt)
 
     async def _run(self) -> None:
+        # Ensure .orchestra directory exists
+        orchestra_dir = Path(self.session.work_path) / ".orchestra"
+        orchestra_dir.mkdir(exist_ok=True)
+
         await self.client.query(
-            f"Session online. Understand and update the monitor.md in the given format. Do NOT log every event, the whole point is to make this easier for the a human to understand what is going on."
+            f"Session online. Understand and update the .orchestra/monitor.md in the given format. Do NOT log every event, the whole point is to make this easier for the a human to understand what is going on."
         )
 
         async for chunk in self.client.receive_response():
@@ -194,7 +198,7 @@ class SessionMonitorWatcher:
         if not sess.work_path:
             return
 
-        monitor_file = Path(sess.work_path) / "monitor.md"
+        monitor_file = Path(sess.work_path) / ".orchestra" / "monitor.md"
 
         if monitor_file.exists():
             try:


### PR DESCRIPTION
This update organizes Orchestra-managed files (designer.md, monitor.md) into a dedicated .orchestra/ folder and automatically adds it to .gitignore on startup.

Changes:
- Add .orchestra/ to .gitignore
- Create ensure_orchestra_in_gitignore() helper function
- Call helper on app startup to auto-update user's .gitignore
- Update designer.md path to .orchestra/designer.md
- Update monitor.md path to .orchestra/monitor.md

This ensures Orchestra's internal files don't clutter the repo or show up as untracked files, improving the user experience.
@codex take a look @lenishor 